### PR TITLE
Chore/npm 18 upgrade

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.17.x]
 
     steps:
     - name: Checkout repository

--- a/.pipelines/app/templates/npmInstall.yml
+++ b/.pipelines/app/templates/npmInstall.yml
@@ -1,7 +1,7 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '16.19.x'
+      versionSpec: '18.x'
 
   - task: Cache@2
     displayName: Cache npm

--- a/.pipelines/app/templates/npmInstall.yml
+++ b/.pipelines/app/templates/npmInstall.yml
@@ -1,7 +1,7 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '18.x'
+      versionSpec: '18.19.x'
 
   - task: Cache@2
     displayName: Cache npm

--- a/.pipelines/app/templates/npmInstall.yml
+++ b/.pipelines/app/templates/npmInstall.yml
@@ -1,7 +1,7 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '18.19.x'
+      versionSpec: '18.17.x'
 
   - task: Cache@2
     displayName: Cache npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,8 +67,8 @@
         "whatwg-fetch": "^3.6.20"
       },
       "engines": {
-        "node": "=18.19.x",
-        "npm": "=10"
+        "node": "=18.17.x",
+        "npm": "=9"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,8 +67,8 @@
         "whatwg-fetch": "^3.6.20"
       },
       "engines": {
-        "node": "=16",
-        "npm": "=8"
+        "node": "=18",
+        "npm": "=9"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,8 +67,8 @@
         "whatwg-fetch": "^3.6.20"
       },
       "engines": {
-        "node": "=18",
-        "npm": "=9"
+        "node": "=18.19.x",
+        "npm": "=10"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "description": "This repo serves at a boilerplate to help stand up a new nextjs app",
   "engines": {
-    "node": "=16",
-    "npm": "=8"
+    "node": "=18",
+    "npm": "=9"
   },
   "scripts": {
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "description": "This repo serves at a boilerplate to help stand up a new nextjs app",
   "engines": {
-    "node": "=18",
-    "npm": "=9"
+    "node": "=18.19.x",
+    "npm": "=10"
   },
   "scripts": {
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "description": "This repo serves at a boilerplate to help stand up a new nextjs app",
   "engines": {
-    "node": "=18.19.x",
-    "npm": "=10"
+    "node": "=18.17.x",
+    "npm": "=9"
   },
   "scripts": {
     "prepare": "husky install",


### PR DESCRIPTION
Will now use node 18.17.1 & npm 9

Unable to upgrade to node 20 & npm 10:
- Azure static sites offer support up to node 20/npm 10
- Azure functions offer support up to node 18/npm 9